### PR TITLE
Add requests package as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'License :: OSI Approved :: MIT License'
         ],
-    install_requires=["fake_useragent"],
+    install_requires=["fake_useragent", "requests"],
     keywords='google trends api search',
     packages=['pytrends'],
 )


### PR DESCRIPTION
On Archlinux (kernel 4.3.3-3) with python 3.5.1 the requests package was missing. Hopefully this fix will improve on that :-)