### PR TITLE
Update text datatype regex to match keywords containing periods

### DIFF
--- a/pytrends/pyGTrends.py
+++ b/pytrends/pyGTrends.py
@@ -204,7 +204,7 @@ def _infer_dtype(val):
         return 'int'
     elif re.match(r'[+-]?\d+%$', val):
         return 'pct'
-    elif re.match(r'[a-zA-Z ]+', val):
+    elif re.match(r'[\w\s\.]+', val):
         return 'text'
     else:
         msg = "val={0} dtype not recognized".format(val)


### PR DESCRIPTION
The API can return keywords containing periods in them such as `python 2.7`.

Updated the dtype match for text to allow for them (also underscores with the `\w` pattern).