### PR TITLE
Catch KeyError when there is value but no name.

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -46,7 +46,10 @@ class TrendReq(object):
         dico = {}
         for u in soup_login:
             if u.has_attr('value'):
-                dico[u['name']] = u['value']
+                try:
+                    dico[u['name']] = u['value']
+                except KeyError:
+                    pass
         # override the inputs with out login and pwd:
         dico['Email'] = self.username
         dico['Passwd'] = self.password


### PR DESCRIPTION
I encountered KeyErrors when constructing the TrendReq object because the _connect() method would assume that any Tag object that contained a 'value' attribute would also have a 'name' attribute. This is not always true.

![10-10-2016_152149](https://cloud.githubusercontent.com/assets/11079627/19248468/2fabf85c-8efe-11e6-8bea-5beedf0260fd.png)

These are the tags containing a 'value' attribute. Notice how one does not contain a 'name' attribute.