### PR TITLE
Handle unexpected response

### DIFF
--- a/pytrends/exceptions.py
+++ b/pytrends/exceptions.py
@@ -1,0 +1,8 @@
+class ResponseError(Exception):
+    """Something was wrong with the response from Google"""
+
+    def __init__(self, message, response):
+        super(Exception, self).__init__(message)
+
+        # pass response so it can be handled upstream
+        self.response = response

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -88,25 +88,30 @@ class TrendReq(object):
         req_url = "https://www.google.com/trends/api/explore"
         req = self.ses.get(req_url, params=token_payload)
 
-        # parse the returned json
-        # strip off garbage characters that break json parser
-        widget_json = req.text[4:]
-        widget_dict = json.loads(widget_json)['widgets']
-        # order of the json matters...
-        first_region_token = True
-        # assign requests
-        for widget in widget_dict:
-            if widget['title'] == 'Interest over time':
-                self.interest_over_time_widget = widget
-            if widget['title'] == 'Interest by region' and first_region_token:
-                self.interest_by_region_widget = widget
-                first_region_token = False
-            if widget['title'] == 'Interest by subregion' and first_region_token:
-                self.interest_by_region_widget = widget
-                first_region_token = False
-            # response for each term, put into a list
-            if widget['title'] == 'Related queries':
-                self.related_queries_widget_list.append(widget)
+        # check if the response is indeed json and throw an exception otherwise
+        if 'application/json' in req.headers['Content-Type']:
+            # parse the returned json
+            # strip off garbage characters that break json parser
+            widget_json = req.text[4:]
+            widget_dict = json.loads(widget_json)['widgets']
+            # order of the json matters...
+            first_region_token = True
+            # assign requests
+            for widget in widget_dict:
+                if widget['title'] == 'Interest over time':
+                    self.interest_over_time_widget = widget
+                if widget['title'] == 'Interest by region' and first_region_token:
+                    self.interest_by_region_widget = widget
+                    first_region_token = False
+                if widget['title'] == 'Interest by subregion' and first_region_token:
+                    self.interest_by_region_widget = widget
+                    first_region_token = False
+                # response for each term, put into a list
+                if widget['title'] == 'Related queries':
+                    self.related_queries_widget_list.append(widget)
+        else:
+            # TODO: raise a more specific error
+            raise (Exception)
         return
 
     def interest_over_time(self):

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -91,7 +91,7 @@ class TrendReq(object):
         req_url = "https://www.google.com/trends/api/explore"
         req = self.ses.get(req_url, params=token_payload)
 
-        # check if the response is indeed json and throw an exception otherwise
+        # check if the response contains json and throw an exception otherwise
         if 'application/json' in req.headers['Content-Type']:
             # parse the returned json
             # strip off garbage characters that break json parser

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -113,6 +113,8 @@ class TrendReq(object):
                 if widget['title'] == 'Related queries':
                     self.related_queries_widget_list.append(widget)
         else:
+            # this is often the case when the amount of keywords in the payload for the IP
+            # is not allowed by Google
             raise exceptions.ResponseError(
                 'The request failed: Google returned a response with code {0}.'.format(req.status_code),
                 response=req

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -4,6 +4,8 @@ import requests
 import json
 import pandas as pd
 from bs4 import BeautifulSoup
+from pytrends import exceptions
+
 if sys.version_info[0] == 2:  # Python 2
     from urllib import quote
 else:  # Python 3
@@ -14,6 +16,7 @@ class TrendReq(object):
     """
     Google Trends API
     """
+
     def __init__(self, google_username, google_password, hl='en-US', tz=360, geo='', custom_useragent=None):
         """
         Initialize hard-coded URLs, HTTP headers, and login parameters
@@ -110,8 +113,10 @@ class TrendReq(object):
                 if widget['title'] == 'Related queries':
                     self.related_queries_widget_list.append(widget)
         else:
-            # TODO: raise a more specific error
-            raise (Exception)
+            raise exceptions.ResponseError(
+                'The request failed: Google returned a response with code {0}.'.format(req.status_code),
+                response=req
+            )
         return
 
     def interest_over_time(self):


### PR DESCRIPTION
As some PyTrends users came across it (see #122), when the response from google doesn't contain JSON, this causes the JSON parser to throw an error. My suggestion is to throw a more enlightening error.