### PR TITLE
Bug fixes and refactor

### DIFF
--- a/pytrends/exceptions.py
+++ b/pytrends/exceptions.py
@@ -1,0 +1,8 @@
+class ResponseError(Exception):
+    """Something was wrong with the response from Google"""
+
+    def __init__(self, message, response):
+        super(Exception, self).__init__(message)
+
+        # pass response so it can be handled upstream
+        self.response = response

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -262,8 +262,8 @@ class TrendReq(object):
         result_df = pd.DataFrame()
 
         # parse the returned json
+        sub_df = pd.DataFrame()
         for trenddate in req_json:
-            sub_df = pd.DataFrame()
             sub_df['date'] = trenddate['date']
             for trend in trenddate['trendsList']:
                 sub_df = sub_df.append(trend, ignore_index=True)

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -164,7 +164,10 @@ class TrendReq(object):
         return result_df
 
     def related_queries(self):
-        """Request data from Google's Related Queries section and return a dictionary of dataframes"""
+        """Request data from Google's Related Queries section and return a dictionary of dataframes
+
+        If no top and/or rising related queries are found, the value for the key "top" and/or "rising" will be null.
+        """
 
         # make the request
         req_url = "https://www.google.com/trends/api/widgetdata/relatedsearches"
@@ -182,12 +185,23 @@ class TrendReq(object):
             # parse the returned json
             # strip off garbage characters that break json parser
             req_json = json.loads(req.text[5:])
+
             # top queries
-            top_df = pd.DataFrame(req_json['default']['rankedList'][0]['rankedKeyword'])
-            top_df = top_df[['query', 'value']]
+            try:
+                top_df = pd.DataFrame(req_json['default']['rankedList'][0]['rankedKeyword'])
+                top_df = top_df[['query', 'value']]
+            except KeyError:
+                # in case no top queries are found, the lines above will throw a KeyError
+                top_df = None
+
             # rising queries
-            rising_df = pd.DataFrame(req_json['default']['rankedList'][1]['rankedKeyword'])
-            rising_df = rising_df[['query', 'value']]
+            try:
+                rising_df = pd.DataFrame(req_json['default']['rankedList'][1]['rankedKeyword'])
+                rising_df = rising_df[['query', 'value']]
+            except KeyError:
+                # in case no rising queries are found, the lines above will throw a KeyError
+                rising_df = None
+
             result_dict[kw] = {'top': top_df, 'rising': rising_df}
         return result_dict
 

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -20,7 +20,7 @@ class TrendReq(object):
     GET_METHOD = 'get'
     POST_METHOD = 'post'
 
-    def __init__(self, google_username, google_password, hl='en-US', tz=360, geo='', custom_useragent=None):
+    def __init__(self, google_username, google_password, hl='en-US', tz=360, geo='', custom_useragent='PyTrends'):
         """
         Initialize hard-coded URLs, HTTP headers, and login parameters
         needed to connect to Google Trends, then connect.
@@ -32,17 +32,14 @@ class TrendReq(object):
         self.url_login = "https://accounts.google.com/ServiceLogin"
         self.url_auth = "https://accounts.google.com/ServiceLoginAuth"
         # custom user agent so users know what "new account signin for Google" is
-        if custom_useragent is None:
-            self.custom_useragent = {'User-Agent': 'PyTrends'}
-        else:
-            self.custom_useragent = {'User-Agent': custom_useragent}
+        self.custom_useragent = {'User-Agent': custom_useragent}
         self._connect()
         self.results = None
 
         # set user defined options used globally
         self.tz = tz
         self.hl = hl
-        self.geo = ''
+        self.geo = geo
         self.kw_list = list()
 
         # intialize widget payloads

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -149,14 +149,14 @@ class TrendReq(object):
     def interest_over_time(self):
         """Request data from Google's Interest Over Time section and return a dataframe"""
 
-        # make the request
-        over_time_payload = dict()
-        # convert to string as requests will mangle
-        over_time_payload['req'] = json.dumps(self.interest_over_time_widget['request'])
-        over_time_payload['token'] = self.interest_over_time_widget['token']
-        over_time_payload['tz'] = self.tz
+        over_time_payload = {
+            # convert to string as requests will mangle
+            'req': json.dumps(self.interest_over_time_widget['request']),
+            'token': self.interest_over_time_widget['token'],
+            'tz': self.tz
+        }
 
-        # parse the returned json
+        # make the request and parse the returned json
         req_json = self._get_data(
             url=TrendReq.INTEREST_OVER_TIME_URL,
             method=TrendReq.GET_METHOD,

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -29,8 +29,8 @@ class TrendReq(object):
         self.password = google_password
         # google rate limit
         self.google_rl = 'You have reached your quota limit. Please try again later.'
-        self.url_login = "https://accounts.google.com/ServiceLogin"
-        self.url_auth = "https://accounts.google.com/ServiceLoginAuth"
+        self.url_login = 'https://accounts.google.com/ServiceLogin'
+        self.url_auth = 'https://accounts.google.com/ServiceLoginAuth'
         # custom user agent so users know what "new account signin for Google" is
         self.custom_useragent = {'User-Agent': custom_useragent}
         self._connect()
@@ -55,7 +55,7 @@ class TrendReq(object):
         """
         self.ses = requests.session()
         login_html = self.ses.get(self.url_login, headers=self.custom_useragent)
-        soup_login = BeautifulSoup(login_html.content, "lxml").find('form').find_all('input')
+        soup_login = BeautifulSoup(login_html.content, 'lxml').find('form').find_all('input')
         form_data = dict()
         for u in soup_login:
             if u.has_attr('value') and u.has_attr('name'):
@@ -94,10 +94,13 @@ class TrendReq(object):
         token_payload = dict()
         self.kw_list = kw_list
         self.geo = geo
-        token_payload['hl'] = self.hl
-        token_payload['tz'] = self.tz
-        token_payload['req'] = {'comparisonItem': [], 'category': cat}
-        token_payload['property'] = gprop
+        token_payload = {
+            'hl': self.hl,
+            'tz': self.tz,
+            'req': {'comparisonItem': [], 'category': cat},
+            'property': gprop,
+        }
+
         # build out json for each keyword
         for kw in self.kw_list:
             keyword_payload = {'keyword': kw, 'time': timeframe, 'geo': self.geo}
@@ -112,7 +115,7 @@ class TrendReq(object):
         """Makes request to Google to get API tokens for interest over time, interest by region and related queries"""
 
         # make the request
-        req_url = "https://www.google.com/trends/api/explore"
+        req_url = 'https://www.google.com/trends/api/explore'
 
         # parse the returned json
         widget_dict = self._get_data(
@@ -142,7 +145,7 @@ class TrendReq(object):
         """Request data from Google's Interest Over Time section and return a dataframe"""
 
         # make the request
-        req_url = "https://www.google.com/trends/api/widgetdata/multiline"
+        req_url = 'https://www.google.com/trends/api/widgetdata/multiline'
         over_time_payload = dict()
         # convert to string as requests will mangle
         over_time_payload['req'] = json.dumps(self.interest_over_time_widget['request'])
@@ -172,7 +175,7 @@ class TrendReq(object):
         """Request data from Google's Interest by Region section and return a dataframe"""
 
         # make the request
-        req_url = "https://www.google.com/trends/api/widgetdata/comparedgeo"
+        req_url = 'https://www.google.com/trends/api/widgetdata/comparedgeo'
         region_payload = dict()
         if self.geo == '':
             self.interest_by_region_widget['request']['resolution'] = resolution
@@ -206,7 +209,7 @@ class TrendReq(object):
         """
 
         # make the request
-        req_url = "https://www.google.com/trends/api/widgetdata/relatedsearches"
+        req_url = 'https://www.google.com/trends/api/widgetdata/relatedsearches'
         related_payload = dict()
         result_dict = dict()
         for request_json in self.related_queries_widget_list:
@@ -248,7 +251,7 @@ class TrendReq(object):
         """Request data from Google's Trending Searches section and return a dataframe"""
 
         # make the request
-        req_url = "https://trends.google.com/trends/hottrends/hotItems"
+        req_url = 'https://trends.google.com/trends/hottrends/hotItems'
         forms = {'ajax': 1, 'pn': 'p1', 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=req_url,
@@ -272,7 +275,7 @@ class TrendReq(object):
         # make the request
         # create the payload
         chart_payload = {'ajax': 1, 'lp': 1, 'geo': geo, 'date': date, 'cat': cat, 'cid': cid}
-        req_url = "https://trends.google.com/trends/topcharts/chart"
+        req_url = 'https://trends.google.com/trends/topcharts/chart'
 
         # parse the returned json
         req_json = self._get_data(
@@ -290,7 +293,7 @@ class TrendReq(object):
         kw_param = quote(keyword)
 
         req_json = self._get_data(
-            url="https://www.google.com/trends/api/autocomplete/" + kw_param,
+            url='https://www.google.com/trends/api/autocomplete/' + kw_param,
             method=TrendReq.GET_METHOD,
             trim_chars=5
         )['default']['topics']

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -166,7 +166,7 @@ class TrendReq(object):
     def related_queries(self):
         """Request data from Google's Related Queries section and return a dictionary of dataframes
 
-        If no top and/or rising related queries are found, the value for the key "top" and/or "rising" will be null.
+        If no top and/or rising related queries are found, the value for the key "top" and/or "rising" will be None
         """
 
         # make the request

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -82,7 +82,10 @@ class TrendReq(object):
             response = self.ses.get(url, **kwargs)
 
         # check if the response contains json and throw an exception otherwise
-        if 'application/json' in response.headers['Content-Type']:
+        # Google mostly sends 'application/json' in the Content-Type header,
+        # but occasionally it sends 'application/javascript
+        if 'application/json' in response.headers['Content-Type'] or \
+                        'application/javascript' in response.headers['Content-Type']:
             # trim initial characters
             # some responses start with garbage characters, like ")]}',"
             # these have to be cleaned before being passed to the json parser

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -88,7 +88,6 @@ class TrendReq(object):
             response = self.ses.post(url, **kwargs)
         else:
             response = self.ses.get(url, **kwargs)
-        print(response.url)
 
         # check if the response contains json and throw an exception otherwise
         # Google mostly sends 'application/json' in the Content-Type header,

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -129,7 +129,8 @@ class TrendReq(object):
         widget_dict = self._get_data(
             url=TrendReq.GENERAL_URL,
             method=TrendReq.GET_METHOD,
-            params=token_payload
+            params=token_payload,
+            trim_chars=4,
         )['widgets']
 
         # order of the json matters...

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -88,6 +88,7 @@ class TrendReq(object):
             response = self.ses.post(url, **kwargs)
         else:
             response = self.ses.get(url, **kwargs)
+        print(response.url)
 
         # check if the response contains json and throw an exception otherwise
         # Google mostly sends 'application/json' in the Content-Type header,
@@ -302,9 +303,11 @@ class TrendReq(object):
 
         # make the request
         kw_param = quote(keyword)
+        parameters = {'hl': self.hl}
 
         req_json = self._get_data(
             url=TrendReq.SUGGESTIONS_URL + kw_param,
+            params=parameters,
             method=TrendReq.GET_METHOD,
             trim_chars=5
         )['default']['topics']

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -75,7 +75,15 @@ class TrendReq(object):
         self.ses.post(TrendReq.AUTH_URL, data=form_data)
 
     def _get_data(self, url, method=GET_METHOD, trim_chars=0, **kwargs):
-        # make request
+        """Send a request to Google and return the JSON response as a Python object
+
+        :param url: the url to which the request will be sent
+        :param method: the HTTP method ('get' or 'post')
+        :param trim_chars: how many characters should be trimmed off the beginning of the content of the response
+            before this is passed to the JSON parser
+        :param kwargs: any extra key arguments passed to the request builder (usually query parameters or data)
+        :return:
+        """
         if method == TrendReq.POST_METHOD:
             response = self.ses.post(url, **kwargs)
         else:


### PR DESCRIPTION
# Related queries - handle case when no related queries were found

I've noticed that the case when no top and/or rising related queries were found was not handled, which threw an exception. My suggestion is to return `None` if one of this data sets are not found, in place of the expected dataframe.

# Handle unexpected response

If a request returned an error, the response body is HTML, not JSON. This was still being passed to the JSON parser, which threw an exception. My suggestion is to throw a more enlightening exception (see #122).

# Suggested queries

It wasn't possible to define the language of the results when requested suggested queries with `TrendReq.suggestions` - I was getting dutch suggestions (since I'm using a dutch IP) when I was interested in US results. Thus I added the possibility to define the `hl` parameter.

# Repeated code

Since the pattern of making a request, reading the response body and passing it to the JSON parser was repeated often, I created a method with that responsibility (`_get_data`).

# Urls

I've created constants to hold the urls used for the requests. This way it's easier to maintain when urls change - also it's easier to access the value of the urls used in case someone using this library needs to do so.

# Constructor

The constructor of `TrendReq` had some issues for which I'm proposing a fix:
- the optional parameter `geo` was not being used, instead `self.geo` was always set as an empty string;
- the custom user agent (`custom_useragent`) optional parameter can be set to `'PyTrends'` by default (instead of `None`);
- the login and auth urls should not be properties of a `TrendReq` object, they should be constant.

# General refactor

Some style cleanup:
- setting the keys and values of dictionaries when instantiating them;
- using single quotes for consistency;
- moving the instantiation of a returned variable to the outside of a loop, in case the loop has no iterations.