### PR TITLE
Fix: exception in interest_over_time

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -183,6 +183,9 @@ class TrendReq(object):
         )
 
         df = pd.DataFrame(req_json['default']['timelineData'])
+        if (df.empty):
+            return df
+        
         df['date'] = pd.to_datetime(df['time'], unit='s')
         df = df.set_index(['date']).sort_index()
         # split list columns into seperate ones, remove brackets and split on comma

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -148,7 +148,7 @@ class TrendReq(object):
         # order of the json matters...
         first_region_token = True
         # clear self.related_queries_widget_list of old keywords'widgets
-        self.related_queries_widget_list.clear()
+        self.related_queries_widget_list[:] = []
         # assign requests
         for widget in widget_dict:
             if widget['title'] == 'Interest over time':


### PR DESCRIPTION
If the query returns an empty data set the pandas dataframe df is empty and df['time'] raise an exception.