### PR TITLE
Updates api endpoints to remove redirects

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -23,13 +23,13 @@ class TrendReq(object):
     LOGIN_URL = 'https://accounts.google.com/ServiceLogin'
     AUTH_URL = 'https://accounts.google.com/ServiceLoginAuth'
 
-    GENERAL_URL = 'https://www.google.com/trends/api/explore'
-    INTEREST_OVER_TIME_URL = 'https://www.google.com/trends/api/widgetdata/multiline'
-    INTEREST_BY_REGION_URL = 'https://www.google.com/trends/api/widgetdata/comparedgeo'
-    RELATED_QUERIES_URL = 'https://www.google.com/trends/api/widgetdata/relatedsearches'
+    GENERAL_URL = 'https://trends.google.com/trends/api/explore'
+    INTEREST_OVER_TIME_URL = 'https://trends.google.com/trends/api/widgetdata/multiline'
+    INTEREST_BY_REGION_URL = 'https://trends.google.com/trends/api/widgetdata/comparedgeo'
+    RELATED_QUERIES_URL = 'https://trends.google.com/trends/api/widgetdata/relatedsearches'
     TRENDING_SEARCHES_URL = 'https://trends.google.com/trends/hottrends/hotItems'
     TOP_CHARTS_URL = 'https://trends.google.com/trends/topcharts/chart'
-    SUGGESTIONS_URL = 'https://www.google.com/trends/api/autocomplete/'
+    SUGGESTIONS_URL = 'https://trends.google.com/trends/api/autocomplete/'
 
     def __init__(self, google_username, google_password, hl='en-US', tz=360, geo='', custom_useragent='PyTrends',
                  proxies=None):
@@ -185,7 +185,7 @@ class TrendReq(object):
         df = pd.DataFrame(req_json['default']['timelineData'])
         if (df.empty):
             return df
-        
+
         df['date'] = pd.to_datetime(df['time'], unit='s')
         df = df.set_index(['date']).sort_index()
         # split list columns into seperate ones, remove brackets and split on comma


### PR DESCRIPTION
It looks like some of the google trends endpoints have changed.  Google redirects you properly, but this may (or may not) have some impact on rate limiting the number of requests one can make.

To test this PR:
1. Add the following code snippet to `examples/example.py` to enable request logging

```
import logging
from httplib import HTTPConnection

HTTPConnection.debuglevel = 1

logging.basicConfig(level=logging.DEBUG)
requests_log = logging.getLogger("requests.packages.urllib3")
requests_log.setLevel(logging.DEBUG)
requests_log.propagate = True
```

2. Run `examples/example.py` and verify that there are indeed 301s being made

3. Apply the patch and rerun `examples/example.py`.  Verify that there are no more 301s and that the returned data is the same as in step 2

I did this all in the REPL (using `execfile`) to persist the returned data structures for easy comparison.  I actually used `ipython` with `%autocomplete 2` to reload the modules...