### PR TITLE
solved ValueError: year is out of range

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -161,7 +161,7 @@ class TrendReq(object):
         if (df.empty):
             return df
 
-        df['date'] = pd.to_datetime(df['time'], unit='s')
+        df['date'] = pd.to_datetime(df['time'].astype(dtype='float64'), unit='s')
         df = df.set_index(['date']).sort_index()
         # split list columns into seperate ones, remove brackets and split on comma
         result_df = df['value'].apply(lambda x: pd.Series(str(x).replace('[', '').replace(']', '').split(',')))


### PR DESCRIPTION
line 164 in interest_over_time function was throwing a ValueError because it couldn't convert the time returned by the GET request. Solved by casting the Series to float64 dtype

working inside virtualenv running Python 3.5 on Mac sierra 10.12.6