### PR TITLE
specify language in trending_searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Returns dictionary of pandas.DataFrames
 
 ### Trending Searches
 
-    pytrends.trending_searches()
+	pytrends.trending_searches(pn='p1') # in English
+	pytrends.trending_searches(pn='p4') # in Japanese
 Returns pandas.DataFrame
 
 <sub><sup>[back to top](#trending_searches)</sub></sup>

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -71,8 +71,8 @@ class TrendReq(object):
         # but occasionally it sends 'application/javascript
         # and sometimes even 'text/javascript
         if 'application/json' in response.headers['Content-Type'] or \
-                        'application/javascript' in response.headers['Content-Type'] or \
-                                        'text/javascript' in response.headers['Content-Type']:
+            'application/javascript' in response.headers['Content-Type'] or \
+                'text/javascript' in response.headers['Content-Type']:
 
             # trim initial characters
             # some responses start with garbage characters, like ")]}',"
@@ -294,11 +294,11 @@ class TrendReq(object):
             result_dict[kw] = {'top': top_df, 'rising': rising_df}
         return result_dict
 
-    def trending_searches(self):
+    def trending_searches(self, pn='p1'):
         """Request data from Google's Trending Searches section and return a dataframe"""
 
         # make the request
-        forms = {'ajax': 1, 'pn': 'p1', 'htd': '', 'htv': 'l'}
+        forms = {'ajax': 1, 'pn': pn, 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=TrendReq.TRENDING_SEARCHES_URL,
             method=TrendReq.POST_METHOD,

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -45,7 +45,7 @@ class TestTrendReq(TestCase):
     def test_trending_searches(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.trending_searches())
+        self.assertIsNotNone(pytrend.trending_searches(pn='p1'))
 
     def test_top_charts(self):
         pytrend = TrendReq()


### PR DESCRIPTION
I modify to get trend by specifying language like:
```
pytrends.trending_searches(pn='p1') # in English
pytrends.trending_searches(pn='p4') # in Japanese
```

Changes are as follows:
- Change `trending_searches` argument so that language can be specified
- Modify test script
- Update README.md
- Apply PEP8