### PR TITLE
add Metro and Region level data support

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ Parameters
 
   - 'CITY' returns city level data
   - 'COUNTRY' returns country level data
+  - 'DMA'  returns Metro level data
+  - 'REGION'  returns Region level data
 
 Returns pandas.DataFrame
 

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -191,6 +191,8 @@ class TrendReq(object):
         region_payload = dict()
         if self.geo == '':
             self.interest_by_region_widget['request']['resolution'] = resolution
+        elif self.geo == 'US' and resolution in ['DMA', 'CITY', 'REGION']:
+            self.interest_by_region_widget['request']['resolution'] = resolution
         # convert to string as requests will mangle
         region_payload['req'] = json.dumps(self.interest_by_region_widget['request'])
         region_payload['token'] = self.interest_by_region_widget['token']


### PR DESCRIPTION
In the old code, when I set `self.geo` to US, `resolution` in `interest_by_region` is actually useless. I changed it to let this method to support 'DMA' and 'CITY'. In the old code, we actually only got 'REGION' level data.