### PR TITLE
use only NID cookie from Google

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -46,7 +46,10 @@ class TrendReq(object):
         self.kw_list = list()
         self.proxies = proxies #add a proxy option
         #proxies format: {"http": "http://192.168.0.1:8888" , "https": "https://192.168.0.1:8888"}
-        self.cookies = requests.get('https://trends.google.com').cookies
+        self.cookies = dict(filter(
+            lambda i: i[0] == 'NID',
+            requests.get('https://trends.google.com').cookies.items()
+        ))
 
         # intialize widget payloads
         self.token_payload = dict()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -12,7 +12,7 @@ class TestTrendReq(TestCase):
         self.assertEqual(pytrend.hl, 'en-US')
         self.assertEqual(pytrend.tz, 360)
         self.assertEqual(pytrend.geo, '')
-        self.assertIsInstance(pytrend.cookies, RequestsCookieJar)
+        self.assertTrue(pytrend.cookies['NID'])
 
     def test_build_payload(self):
         """Should return the widgets to get data"""


### PR DESCRIPTION
As commented by @RKushnir pointed out the NID cookie is enough to solve this (https://github.com/GeneralMills/pytrends/issues/243#issuecomment-392872309). Therefore only the NID cookie is included now.

Unfortunatelly I could not come up with a more clever filter and test assert, so feel free to enhance those.