### PR TITLE
fix(request): send accept-language header with each request

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -51,7 +51,9 @@ class TrendReq(object):
         #proxies format: {"http": "http://192.168.0.1:8888" , "https": "https://192.168.0.1:8888"}
         self.cookies = dict(filter(
             lambda i: i[0] == 'NID',
-            requests.get('https://trends.google.com').cookies.items()
+            requests.get(
+                'https://trends.google.com/?geo={geo}'.format(geo=hl[-2:])
+            ).cookies.items()
         ))
 
         # intialize widget payloads
@@ -72,6 +74,7 @@ class TrendReq(object):
         :return:
         """
         s = requests.session()
+        s.headers.update({'accept-language': self.hl})
         if self.proxies != '':
             s.proxies.update(self.proxies)
         if method == TrendReq.POST_METHOD:
@@ -377,29 +380,29 @@ class TrendReq(object):
     def get_historical_interest(self, keywords, year_start=2018, month_start=1, day_start=1, hour_start=0, year_end=2018, month_end=2, day_end=1, hour_end= 0, cat=0, geo='', gprop='', sleep=0):
         """Gets historical hourly data for interest by chunking requests to 1 week at a time (which is what Google allows)"""
 
-        # construct datetime obejcts - raises ValueError if invalid parameters       
+        # construct datetime obejcts - raises ValueError if invalid parameters
         start_date = datetime(year_start, month_start, day_start, hour_start)
         end_date = datetime(year_end, month_end, day_end, hour_end)
 
-        # the timeframe has to be in 1 week intervals or Google will reject it 
+        # the timeframe has to be in 1 week intervals or Google will reject it
         delta = timedelta(days=7)
 
         df = pd.DataFrame()
 
         date_iterator = start_date
-        date_iterator += delta 
+        date_iterator += delta
 
         while True:
             if (date_iterator > end_date):
-                # has retrieved all of the data 
+                # has retrieved all of the data
                 break
 
-            # format date to comply with API call 
+            # format date to comply with API call
             start_date_str = start_date.strftime('%Y-%m-%dT%H')
             date_iterator_str = date_iterator.strftime('%Y-%m-%dT%H')
             tf = start_date_str + ' ' + date_iterator_str
 
-            try: 
+            try:
                 self.build_payload(keywords,cat, tf, geo, gprop)
                 week_df = self.interest_over_time()
                 df = df.append(week_df)
@@ -408,10 +411,10 @@ class TrendReq(object):
                 pass
 
             start_date += delta
-            date_iterator += delta 
+            date_iterator += delta
 
-            # just in case you are rate-limited by Google. Recommended is 60 if you are. 
+            # just in case you are rate-limited by Google. Recommended is 60 if you are.
             if sleep > 0:
                 time.sleep(sleep)
 
-        return df 
+        return df


### PR DESCRIPTION
In #259  I described how to get language specific data on related_topics request, as this is not yet the case.

By sending the accept-language (value is the hl parameter of the TrendReq object) header in each request, we get the data in this specified language (via hl param).

Additionally someone mentioned in #243 that the cookie gathering on init, should also be done to a language specific page, to prevent redirects (optimizing). This is also done in here, because it is somewhat language related.