### PR TITLE
Added ability to return Rising Topics

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import json
 import sys
 
+from pandas.io.json.normalize import nested_to_record
 import pandas as pd
 import requests
 
@@ -259,13 +260,21 @@ class TrendReq(object):
 
             # top topics
             try:
-                df = pd.DataFrame(req_json['default']['rankedList'][0]['rankedKeyword'])
-                df = pd.DataFrame(df['topic'].tolist()).join(df[['value']])
+                top_list = req_json['default']['rankedList'][0]['rankedKeyword']
+                df_top = pd.DataFrame([nested_to_record(d, sep='_') for d in top_list])
             except KeyError:
                 # in case no top topics are found, the lines above will throw a KeyError
-                df = None
+                df_top = None
 
-            result_dict[kw] = df
+            #rising topics
+            try:
+                rising_list = req_json['default']['rankedList'][1]['rankedKeyword']
+                df_rising = pd.DataFrame([nested_to_record(d, sep='_')  for d in rising_list])
+            except KeyError:
+                # in case no rising topics are found, the lines above will throw a KeyError
+                df_rising = None
+
+            result_dict[kw] = {'rising': df_rising, 'top' : df_top}
         return result_dict
 
     def related_queries(self):


### PR DESCRIPTION
related_topics() will now return a dictionary for each keyword, containing two keys: 'rising' and 'top'.
The values for these keys are DataFrames containing the rising and the top topics respectively.