### PR TITLE
Fix failed import due to renaming pandas module

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 
 import pandas as pd
 import requests
-from pandas.io.json.normalize import nested_to_record
+from pandas.io.json._normalize import nested_to_record
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 


### PR DESCRIPTION
Fixed issue #317 

FYI: https://github.com/pandas-dev/pandas/commit/845d4b89e98d5d1678acb2007211fcf687001d12#diff-085b16cf7a5c99b9fb569986b8be613b