### PR TITLE
Updated integer date format for top_charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ Parameters
 * `date`
 
   - *Required*
-  - YYYY or YYYYMM integer
-  - Example `201611` for November 2016 Top Chart data
+  - YYYY or YYYY-MM integer
+  - Example `2016-11` for November 2016 Top Chart data
 
 Returns pandas.DataFrame
 


### PR DESCRIPTION
Passing the date argument requires a YYYY-MM format instead of YYYYMM format.
Using the latter causes an IndexError exception.