### PR TITLE
override proxies, if proxies set in request_params

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -69,26 +69,37 @@ class TrendReq(object):
         Removes proxy from the list on proxy error
         """
         while True:
-            if len(self.proxies) > 0:
-                proxy = {'https': self.proxies[self.proxy_index]}
+            if "proxies" in self.request_args:
+                try:
+                    return dict(filter(lambda i: i[0] == 'NID', requests.get(
+                        'https://trends.google.com/?geo={geo}'.format(
+                            geo=self.hl[-2:]),
+                        timeout=self.timeout,
+                        **self.requests_args
+                    ).cookies.items()))
+                except:
+                    continue
             else:
-                proxy = ''
-            try:
-                return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                    'https://trends.google.com/?geo={geo}'.format(
-                        geo=self.hl[-2:]),
-                    timeout=self.timeout,
-                    proxies=proxy,
-                    **self.requests_args
-                ).cookies.items()))
-            except requests.exceptions.ProxyError:
-                print('Proxy error. Changing IP')
-                if len(self.proxies) > 1:
-                    self.proxies.remove(self.proxies[self.proxy_index])
+                if len(self.proxies) > 0:
+                    proxy = {'https': self.proxies[self.proxy_index]}
                 else:
-                    print('No more proxies available. Bye!')
-                    raise
-                continue
+                    proxy = ''
+                try:
+                    return dict(filter(lambda i: i[0] == 'NID', requests.get(
+                        'https://trends.google.com/?geo={geo}'.format(
+                            geo=self.hl[-2:]),
+                        timeout=self.timeout,
+                        proxies=proxy,
+                        **self.requests_args
+                    ).cookies.items()))
+                except requests.exceptions.ProxyError:
+                    print('Proxy error. Changing IP')
+                    if len(self.proxies) > 1:
+                        self.proxies.remove(self.proxies[self.proxy_index])
+                    else:
+                        print('No more proxies available. Bye!')
+                        raise
+                    continue
 
     def GetNewProxy(self):
         """

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -69,7 +69,7 @@ class TrendReq(object):
         Removes proxy from the list on proxy error
         """
         while True:
-            if "proxies" in self.request_args:
+            if "proxies" in self.requests_args:
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
                         'https://trends.google.com/?geo={geo}'.format(


### PR DESCRIPTION
When request_args is passed, there's this error:
![image](https://user-images.githubusercontent.com/12519843/82658504-003ae380-9c1f-11ea-8085-4e39943ad625.png)

Because the keyword `proxies` is passed twice