### PR TITLE
[WIP] Test and fix interest_by_region() for geo/resolution combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Only good until Google changes their backend again :-P. When that happens feel f
 
 ## Requirements
 
-* Written for both Python 2.7+ and Python 3.3+
+* Written for Python 3.3+
 * Requires Requests, lxml, Pandas
 
 <sub><sup>[back to top](#pytrends)</sub></sup>

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -252,12 +252,9 @@ class TrendReq(object):
             raise ValueError('resolution must be DMA, CITY, REGION, or COUNTRY')
         # make the request
         region_payload = dict()
-        if self.geo == '':
-            self.interest_by_region_widget['request'][
-                'resolution'] = resolution
-        elif self.geo == 'US' and resolution in ['DMA', 'CITY', 'REGION']:
-            self.interest_by_region_widget['request'][
-                'resolution'] = resolution
+        if resolution == 'DMA' and self.geo[:2] != 'US':
+            raise ValueError('DMA can only be provided for US and US states')
+        self.interest_by_region_widget['request']['resolution'] = resolution
 
         self.interest_by_region_widget['request'][
             'includeLowSearchVolumeGeos'] = inc_low_vol

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -254,6 +254,8 @@ class TrendReq(object):
         region_payload = dict()
         if resolution == 'COUNTRY' and self.geo != '':
             raise ValueError('COUNTRY resolution is only available for worldwide queries')
+        if resolution == 'REGION' and self.geo == '':
+            raise ValueError('REGION resolution is not available for worldwide queries.')
         if resolution == 'DMA' and self.geo[:2] != 'US':
             raise ValueError('DMA resolution is only available for US and US states')
         self.interest_by_region_widget['request']['resolution'] = resolution

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -252,8 +252,10 @@ class TrendReq(object):
             raise ValueError('resolution must be DMA, CITY, REGION, or COUNTRY')
         # make the request
         region_payload = dict()
+        if resolution == 'COUNTRY' and self.geo != '':
+            raise ValueError('COUNTRY resolution is only available for worldwide queries')
         if resolution == 'DMA' and self.geo[:2] != 'US':
-            raise ValueError('DMA can only be provided for US and US states')
+            raise ValueError('DMA resolution is only available for US and US states')
         self.interest_by_region_widget['request']['resolution'] = resolution
 
         self.interest_by_region_widget['request'][

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import json
 import sys
 import time
@@ -14,10 +12,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 from pytrends import exceptions
 
-if sys.version_info[0] == 2:  # Python 2
-    from urllib import quote
-else:  # Python 3
-    from urllib.parse import quote
+from urllib.parse import quote
 
 
 class TrendReq(object):

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -248,6 +248,8 @@ class TrendReq(object):
                            inc_geo_code=False):
         """Request data from Google's Interest by Region section and return a dataframe"""
 
+        if resolution not in ['DMA', 'CITY', 'REGION', 'COUNTRY']:
+            raise ValueError('resolution must be DMA, CITY, REGION, or COUNTRY')
         # make the request
         region_payload = dict()
         if self.geo == '':

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -280,7 +280,7 @@ class TrendReq(object):
         # rename the column with the search keyword
         df = df[['geoName', 'geoCode', 'value']].set_index(
             ['geoName']).sort_index()
-        # split list columns into seperate ones, remove brackets and split on comma
+        # split list columns into separate ones, remove brackets and split on comma
         result_df = df['value'].apply(lambda x: pd.Series(
             str(x).replace('[', '').replace(']', '').split(',')))
         if inc_geo_code:
@@ -393,7 +393,7 @@ class TrendReq(object):
         """Request data from Google's Hot Searches section and return a dataframe"""
 
         # make the request
-        # forms become obsolute due to the new TRENDING_SEACHES_URL
+        # forms become obsolete due to the new TRENDING_SEARCHES_URL
         # forms = {'ajax': 1, 'pn': pn, 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=TrendReq.TRENDING_SEARCHES_URL,
@@ -474,7 +474,7 @@ class TrendReq(object):
                                 geo='', gprop='', sleep=0):
         """Gets historical hourly data for interest by chunking requests to 1 week at a time (which is what Google allows)"""
 
-        # construct datetime obejcts - raises ValueError if invalid parameters
+        # construct datetime objects - raises ValueError if invalid parameters
         initial_start_date = start_date = datetime(year_start, month_start,
                                                    day_start, hour_start)
         end_date = datetime(year_end, month_end, day_end, hour_end)

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -38,7 +38,7 @@ class TestTrendReq(TestCase):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertRaises(InvalidGeoException, pytrend.interest_by_region(resolution='DMA'))
+        self.assertRaises(ValueError, pytrend.interest_by_region(resolution='DMA'))
 
     def test_interest_by_subregion(self):
         pytrend = TrendReq()
@@ -74,7 +74,7 @@ class TestTrendReq(TestCase):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
-        self.assertRaises(InvalidGeoException, pytrend.interest_by_region(resolution='DMA'))
+        self.assertRaises(ValueError, pytrend.interest_by_region(resolution='DMA'))
 
     def test_interest_by_subregion_ca(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts(cid='actors', date=201611))
+        self.assertIsNotNone(pytrend.top_charts(date=201611))
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -83,7 +83,8 @@ class TestTrendReq(TestCase):
         # Interest by country (default resolution) only works for world.
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
-        self.assertIsNotNone(pytrend.interest_by_region(resolution='COUNTRY'))
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region()
 
     def test_interest_by_subregion_ca(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts(date=201611))
+        self.assertIsNotNone(pytrend.top_charts())
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts())
+        self.assertIsNotNone(pytrend.top_charts(date=2019))
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -35,24 +35,28 @@ class TestTrendReq(TestCase):
         self.assertIsNotNone(pytrend.interest_by_region())
 
     def test_interest_by_badregion(self):
+        # Test an invalid resolution.
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         with self.assertRaises(ValueError):
             pytrend.interest_by_region(resolution='BADREGION')
 
-    def test_interest_by_dma(self):
+    def test_interest_by_dma_world(self):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         with self.assertRaises(ValueError):
             pytrend.interest_by_region(resolution='DMA')
 
-    def test_interest_by_subregion(self):
+    def test_interest_by_subregion_world(self):
+        # Subregion isn't available for world.
+        # Note: The UI calls it region in world view, but it's actually country.
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region(resolution='REGION')
 
-    def test_interest_by_city(self):
+    def test_interest_by_city_world(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -47,7 +47,7 @@ class TestTrendReq(TestCase):
     def test_trending_searches(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.trending_searches(pn='p1'))
+        self.assertIsNotNone(pytrend.trending_searches())
 
     def test_top_charts(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -34,11 +34,18 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region())
 
+    def test_interest_by_badregion(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region(resolution='BADREGION')
+
     def test_interest_by_dma(self):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertRaises(ValueError, pytrend.interest_by_region(resolution='DMA'))
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region(resolution='DMA')
 
     def test_interest_by_subregion(self):
         pytrend = TrendReq()
@@ -74,7 +81,8 @@ class TestTrendReq(TestCase):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
-        self.assertRaises(ValueError, pytrend.interest_by_region(resolution='DMA'))
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region(resolution='DMA')
 
     def test_interest_by_subregion_ca(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -34,6 +34,37 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region())
 
+    def test_interest_by_dma(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='DMA'))
+
+    def test_interest_by_subregion(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
+
+    def test_interest_by_city(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
+
+    def test_interest_by_dma_ca(self):
+        # DMA don't exist in Canada, so this should return an error.
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
+        self.assertRaises(InvalidGeoException, pytrend.interest_by_region(resolution='DMA'))
+
+    def test_interest_by_subregion_ca(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
+
+    def test_interest_by_city_ca(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
+        
     def test_related_topics(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -49,6 +49,26 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
 
+    def test_interest_by_region_us(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
+        self.assertIsNotNone(pytrend.interest_by_region())
+
+    def test_interest_by_dma_us(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='DMA'))
+
+    def test_interest_by_subregion_us(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
+
+    def test_interest_by_city_us(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
+
     def test_interest_by_dma_ca(self):
         # DMA don't exist in Canada, so this should return an error.
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -29,7 +29,7 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_over_time())
 
-    def test_interest_by_region(self):
+    def test_interest_by_country_world(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region())
@@ -57,10 +57,12 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
 
-    def test_interest_by_region_us(self):
+    def test_interest_by_country_us(self):
+        # Interest by country (default resolution) only works for world.
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
-        self.assertIsNotNone(pytrend.interest_by_region())
+        with self.assertRaises(ValueError):
+            pytrend.interest_by_region()
 
     def test_interest_by_dma_us(self):
         pytrend = TrendReq()
@@ -77,17 +79,23 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='US')
         self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
 
+    def test_interest_by_country_ca(self):
+        # Interest by country (default resolution) only works for world.
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='COUNTRY'))
+
+    def test_interest_by_subregion_ca(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
+
     def test_interest_by_dma_ca(self):
         # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
         with self.assertRaises(ValueError):
             pytrend.interest_by_region(resolution='DMA')
-
-    def test_interest_by_subregion_ca(self):
-        pytrend = TrendReq()
-        pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
-        self.assertIsNotNone(pytrend.interest_by_region(resolution='REGION'))
 
     def test_interest_by_city_ca(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -35,9 +35,10 @@ class TestTrendReq(TestCase):
         self.assertIsNotNone(pytrend.interest_by_region())
 
     def test_interest_by_dma(self):
+        # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.interest_by_region(resolution='DMA'))
+        self.assertRaises(InvalidGeoException, pytrend.interest_by_region(resolution='DMA'))
 
     def test_interest_by_subregion(self):
         pytrend = TrendReq()
@@ -70,7 +71,7 @@ class TestTrendReq(TestCase):
         self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
 
     def test_interest_by_dma_ca(self):
-        # DMA don't exist in Canada, so this should return an error.
+        # DMA is only available for US and US states (subregions).
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'], geo='CA')
         self.assertRaises(InvalidGeoException, pytrend.interest_by_region(resolution='DMA'))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
This adds tests for a range of geo/resolution combinations, and attempts to provide functionality for the ones that should work, and raise errors for those that shouldn't (it doesn't yet pass all tests). It also applies PR #406 (to leverage its test fixes), so shows other changes from that.

In particular, based on exploring Google Trends, it looks like these geo/resolution restrictions should be implemented (plus potentially more if the geo is a city, but I haven't implemented these):
1. `COUNTRY` resolution is only available for worldwide queries
2. `REGION` resolution is not available for worldwide queries
3. `DMA` resolution is only available for US and US states (subregions)

Adding these restrictions, the function now passes those tests (correctly throws `ValueError`s). But it doesn't yet work in all cases I believe it should work. Here are the errors it throws:
```
FAILED test_trendReq.py::TestTrendReq::test_interest_by_city - KeyError: "['geoCode'] not in index"
FAILED test_trendReq.py::TestTrendReq::test_interest_by_city_ca - KeyError: "['geoCode'] not in index"
FAILED test_trendReq.py::TestTrendReq::test_interest_by_city_us - KeyError: "['geoCode'] not in index"
```

See #392 for a discussion of these errors. In https://github.com/GeneralMills/pytrends/issues/392#issuecomment-632726508, @shevajia linked to [this fix](https://github.com/shevajia/PytrendsAddon/blob/master/PytrendsAddon.py) in a different repo. @shevajia, could you please suggest how to modify this code to integrate your enhancement and resolve these errors?