### PR TITLE
Ensure isPartial is a bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Only good until Google changes their backend again :-P. When that happens feel f
 
 ## Requirements
 
-* Written for both Python 2.7+ and Python 3.3+
+* Written for Python 3.3+
 * Requires Requests, lxml, Pandas
 
 <sub><sup>[back to top](#pytrends)</sub></sup>

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -236,6 +236,8 @@ class TrendReq(object):
             result_df2 = df['isPartial'].apply(lambda x: pd.Series(
                 str(x).replace('[', '').replace(']', '').split(',')))
             result_df2.columns = ['isPartial']
+            # Change to a bool type.
+            result_df2.isPartial = result_df2.isPartial == 'True'
             # concatenate the two dataframes
             final = pd.concat([result_df, result_df2], axis=1)
         else:

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function, unicode_literals
-
 import json
 import sys
 import time
@@ -14,10 +12,7 @@ from requests.packages.urllib3.util.retry import Retry
 
 from pytrends import exceptions
 
-if sys.version_info[0] == 2:  # Python 2
-    from urllib import quote
-else:  # Python 3
-    from urllib.parse import quote
+from urllib.parse import quote
 
 
 class TrendReq(object):

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -280,7 +280,7 @@ class TrendReq(object):
         # rename the column with the search keyword
         df = df[['geoName', 'geoCode', 'value']].set_index(
             ['geoName']).sort_index()
-        # split list columns into seperate ones, remove brackets and split on comma
+        # split list columns into separate ones, remove brackets and split on comma
         result_df = df['value'].apply(lambda x: pd.Series(
             str(x).replace('[', '').replace(']', '').split(',')))
         if inc_geo_code:
@@ -393,7 +393,7 @@ class TrendReq(object):
         """Request data from Google's Hot Searches section and return a dataframe"""
 
         # make the request
-        # forms become obsolute due to the new TRENDING_SEACHES_URL
+        # forms become obsolete due to the new TRENDING_SEARCHES_URL
         # forms = {'ajax': 1, 'pn': pn, 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=TrendReq.TRENDING_SEARCHES_URL,
@@ -474,7 +474,7 @@ class TrendReq(object):
                                 geo='', gprop='', sleep=0):
         """Gets historical hourly data for interest by chunking requests to 1 week at a time (which is what Google allows)"""
 
-        # construct datetime obejcts - raises ValueError if invalid parameters
+        # construct datetime objects - raises ValueError if invalid parameters
         initial_start_date = start_date = datetime(year_start, month_start,
                                                    day_start, hour_start)
         end_date = datetime(year_end, month_end, day_end, hour_end)

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts(cid='actors', date=201611))
+        self.assertIsNotNone(pytrend.top_charts(date=201611))
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+import pandas.api.types as ptypes
 
 from pytrends.request import TrendReq
 
@@ -58,3 +59,16 @@ class TestTrendReq(TestCase):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.suggestions(keyword='pizza'))
+
+    def test_ispartial_dtype(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        df = pytrend.interest_over_time()
+        assert ptypes.is_bool_dtype(df.isPartial)
+
+    def test_ispartial_dtype_timeframe_all(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'],
+                              timeframe='all')
+        df = pytrend.interest_over_time()
+        assert ptypes.is_bool_dtype(df.isPartial)

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts(date=201611))
+        self.assertIsNotNone(pytrend.top_charts())
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -52,7 +52,7 @@ class TestTrendReq(TestCase):
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.top_charts())
+        self.assertIsNotNone(pytrend.top_charts(date=2019))
 
     def test_suggestions(self):
         pytrend = TrendReq()

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -47,7 +47,7 @@ class TestTrendReq(TestCase):
     def test_trending_searches(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
-        self.assertIsNotNone(pytrend.trending_searches(pn='p1'))
+        self.assertIsNotNone(pytrend.trending_searches())
 
     def test_top_charts(self):
         pytrend = TrendReq()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
Fixes #353 and fixes #399, which report that the `isPartial` column is returned as a bool, except when `timeframe='all'` is passed, in which case it's a string (`'True'`/`'False'`). This adds tests for `isPartial` to be a bool in both the default and `timeframe='all'` cases, and fixes the issue in the latter case.

It also applies PR #406 (to leverage its test fixes), so shows other changes from that.

All tests pass.