### PR TITLE
removed keywords restriction in payloads

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -142,7 +142,7 @@ class TrendReq(object):
                 'response with code {0}.'.format(response.status_code),
                 response=response)
 
-    def build_payload(self, kw_list, cat=0, timeframe='today 5-y', geo='',
+    def build_payload(self, kw_list = [], cat=0, timeframe='today 5-y', geo='',
                       gprop=''):
         """Create the payload for related queries, interest over time and interest by region"""
         if gprop not in ['', 'images', 'news', 'youtube', 'froogle']:
@@ -155,10 +155,15 @@ class TrendReq(object):
             'req': {'comparisonItem': [], 'category': cat, 'property': gprop}
         }
 
-        # build out json for each keyword
-        for kw in self.kw_list:
-            keyword_payload = {'keyword': kw, 'time': timeframe,
-                               'geo': self.geo}
+        # build out json for each keyword if there are keywords
+        if len(kw_list) > 0:
+            for kw in self.kw_list:
+                keyword_payload = {'keyword': kw, 'time': timeframe,
+                                   'geo': self.geo}
+                self.token_payload['req']['comparisonItem'].append(keyword_payload)
+        # build out json if there are no keywords
+        else:
+            keyword_payload = {'keyword': '', 'time': timeframe, 'geo': self.geo}
             self.token_payload['req']['comparisonItem'].append(keyword_payload)
         # requests will mangle this if it is not a string
         self.token_payload['req'] = json.dumps(self.token_payload['req'])
@@ -307,9 +312,6 @@ class TrendReq(object):
         related_payload = dict()
         result_dict = dict()
         for request_json in self.related_topics_widget_list:
-            # ensure we know which keyword we are looking at rather than relying on order
-            kw = request_json['request']['restriction'][
-                'complexKeywordsRestriction']['keyword'][0]['value']
             # convert to string as requests will mangle
             related_payload['req'] = json.dumps(request_json['request'])
             related_payload['token'] = request_json['token']
@@ -343,7 +345,7 @@ class TrendReq(object):
                 # in case no rising topics are found, the lines above will throw a KeyError
                 df_rising = None
 
-            result_dict[kw] = {'rising': df_rising, 'top': df_top}
+            result_dict = {'rising': df_rising, 'top': df_top}
         return result_dict
 
     def related_queries(self):
@@ -356,9 +358,6 @@ class TrendReq(object):
         related_payload = dict()
         result_dict = dict()
         for request_json in self.related_queries_widget_list:
-            # ensure we know which keyword we are looking at rather than relying on order
-            kw = request_json['request']['restriction'][
-                'complexKeywordsRestriction']['keyword'][0]['value']
             # convert to string as requests will mangle
             related_payload['req'] = json.dumps(request_json['request'])
             related_payload['token'] = request_json['token']
@@ -390,7 +389,7 @@ class TrendReq(object):
                 # in case no rising queries are found, the lines above will throw a KeyError
                 rising_df = None
 
-            result_dict[kw] = {'top': top_df, 'rising': rising_df}
+            result_dict = {'top': top_df, 'rising': rising_df}
         return result_dict
 
     def trending_searches(self, pn='united_states'):


### PR DESCRIPTION
removed keywords restriction in order to look for most searched topics and queries during a certain period of time without having specified any keyword, as in:

https://trends.google.com/trends/explore?date=today%201-m&geo=US