### PR TITLE
Update README.md information about timeframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ Many API methods use the following:
     - By Month: ```'today #-m'``` where # is the number of months from that date to pull data for
       - For example: ``'today 3-m'`` would get data from today to 3months ago
       - **NOTE** Google uses UTC date as *'today'*
-      - **Work for 1, 3, 12 months only!**
+      - **Works for 1, 3, 12 months only!**
 
     - Daily: ```'now #-d'``` where # is the number of days from that date to pull data for
       - For example: ``'now 7-d'`` would get data from the last week
-      - **Work for 1, 7 days only!**
+      - **Works for 1, 7 days only!**
 
     - Hourly: ```'now #-H'``` where # is the number of hours from that date to pull data for
       - For example: ``'now 1-H'`` would get data from the last hour
-      - **Work for 1, 4 hours only!**
+      - **Works for 1, 4 hours only!**
 
 * `gprop`
 

--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ Many API methods use the following:
     - By Month: ```'today #-m'``` where # is the number of months from that date to pull data for
       - For example: ``'today 3-m'`` would get data from today to 3months ago
       - **NOTE** Google uses UTC date as *'today'*
-      - Seems to only work for 1, 2, 3 months only
+      - **!** Work for 1, 3, 12 months only
 
     - Daily: ```'now #-d'``` where # is the number of days from that date to pull data for
       - For example: ``'now 7-d'`` would get data from the last week
-      - Seems to only work for 1, 7 days only
+      - **!** Work for 1, 7 days only
 
     - Hourly: ```'now #-H'``` where # is the number of hours from that date to pull data for
       - For example: ``'now 1-H'`` would get data from the last hour
-      - Seems to only work for 1, 4 hours only
+      - **!** Work for 1, 4 hours only
 
 * `gprop`
 

--- a/README.md
+++ b/README.md
@@ -176,15 +176,15 @@ Many API methods use the following:
     - By Month: ```'today #-m'``` where # is the number of months from that date to pull data for
       - For example: ``'today 3-m'`` would get data from today to 3months ago
       - **NOTE** Google uses UTC date as *'today'*
-      - **!** Work for 1, 3, 12 months only
+      - **Work for 1, 3, 12 months only!**
 
     - Daily: ```'now #-d'``` where # is the number of days from that date to pull data for
       - For example: ``'now 7-d'`` would get data from the last week
-      - **!** Work for 1, 7 days only
+      - **Work for 1, 7 days only!**
 
     - Hourly: ```'now #-H'``` where # is the number of hours from that date to pull data for
       - For example: ``'now 1-H'`` would get data from the last hour
-      - **!** Work for 1, 4 hours only
+      - **Work for 1, 4 hours only!**
 
 * `gprop`
 


### PR DESCRIPTION
Actually, google "2-m" timeframe is deprecated, but there is a new "12-m" one (which is handier in my opinion). 

Other timeframes work well, so I bolded the information to draw attention and removed the "seems" phrase.