### PR TITLE
Top charts date must be a year

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,8 +287,10 @@ Parameters
 * `date`
 
   - *Required*
-  - YYYY or YYYY-MM integer
-  - Example `2016-11` for November 2016 Top Chart data
+  - YYYY integer
+  - Example `2019` for the year 2019 Top Chart data
+  - **Note** Google removed support for monthly queries (e.g. YYYY-MM)
+  - **Note** Google does not return data for the current year
 
 Returns pandas.DataFrame
 

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -427,6 +427,12 @@ class TrendReq(object):
 
     def top_charts(self, date, hl='en-US', tz=300, geo='GLOBAL'):
         """Request data from Google's Top Charts section and return a dataframe"""
+
+        try:
+            date = int(date)
+        except:
+            raise ValueError('The date must be a year with format YYYY. See https://github.com/GeneralMills/pytrends/issues/355')
+        
         # create the payload
         chart_payload = {'hl': hl, 'tz': tz, 'date': date, 'geo': geo,
                          'isMobile': False}
@@ -438,8 +444,11 @@ class TrendReq(object):
             trim_chars=5,
             params=chart_payload,
             **self.requests_args
-        )['topCharts'][0]['listItems']
-        df = pd.DataFrame(req_json)
+        )
+        try:
+            df = pd.DataFrame(req_json['topCharts'][0]['listItems'])
+        except IndexError:
+            df = None
         return df
 
     def suggestions(self, keyword):


### PR DESCRIPTION
Fix #355 and #418 

The top_charts function crashes with `IndexError: list index out of range` when called with a date using the YYYY-MM format. This is because Google removed support for monthly queries.

- Added basic validation to the `date` parameter (must be in integer)
- Noticed that passing current year (2020) doesn't return data and crashes. Applied the pattern used in other parts of the library and returned None instead.
- Played with the idea of adding a year=None parameter but decided to revert it back since having both a date and an optional year parameters was confusing. Also the Google Trend API parameter itself is still called `date` so it's simpler to keep that name for the time being.
- Updated the documentation