### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with io.open(os.path.join(dir, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='pytrends',
-    version='4.7.3',
+    version='4.7.4',
     description='Pseudo API for Google Trends',
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -28,7 +28,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License'
     ],
-    install_requires=['requests', 'pandas>=0.25', 'lxml'],
+    install_requires=['requests>=2.0', 'pandas>=0.25', 'lxml'],
     keywords='google trends api search',
     packages=['pytrends'],
 )


### PR DESCRIPTION
`from requests.packages.urllib3.util.retry import Retry` will only work in requests v2
It will fail due to an older version of urllib3 in v1 of requests.