### PR TITLE
Append search traffic column to the returned Dataframe of the today_searches method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Only good until Google changes their backend again :-P. When that happens feel f
     * [Related Topics](#related-topics)
     * [Related Queries](#related-queries)
     * [Trending Searches](#trending-searches)
+    * [Today Searches](#today-searches)
     * [Top Charts](#top-charts)
     * [Suggestions](#suggestions)
 
@@ -113,6 +114,8 @@ The following API methods are available:
 * [Related Queries](#related-queries): returns data for the related keywords to a provided keyword shown on Google Trends' Related Queries section.
 
 * [Trending Searches](#trending-searches): returns data for latest trending searches shown on Google Trends' Trending Searches section.
+
+* [Today Searches](#today-searches): returns data for the latest daily search trends shown on Google Trends' Trending Searches section.
 
 * [Top Charts](#top-charts): returns the data for a given topic shown in Google Trends' Top Charts section.
 
@@ -273,6 +276,15 @@ Returns dictionary of pandas.DataFrames
 
 	pytrends.trending_searches(pn='united_states') # trending searches in real time for United States
 	pytrends.trending_searches(pn='japan') # Japan
+
+Returns pandas.DataFrame
+
+<sub><sup>[back to top](#trending_searches)</sub></sup>
+
+### Today Searches
+
+	pytrends.today_searches(pn='US') # daily search trends with traffic for United States
+	pytrends.today_searches(pn='JP') # Japan
 
 Returns pandas.DataFrame
 

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -435,11 +435,13 @@ class TrendReq(object):
         )['default']['trendingSearchesDays'][0]['trendingSearches']
         result_df = pd.DataFrame()
         # parse the returned json
-        sub_df = pd.DataFrame()
+        title_df = pd.DataFrame()
+        traffic_df = pd.DataFrame()
         for trend in req_json:
-            sub_df = sub_df.append(trend['title'], ignore_index=True)
-        result_df = pd.concat([result_df, sub_df])
-        return result_df.iloc[:, -1]
+            title_df = title_df.append(trend['title'], ignore_index=True)
+            traffic_df = traffic_df.append({'searches': trend['formattedTraffic']}, ignore_index=True)
+        result_df = pd.concat([result_df, title_df, traffic_df], axis=1)
+        return result_df.iloc[:, 1:]
 
     def top_charts(self, date, hl='en-US', tz=300, geo='GLOBAL'):
         """Request data from Google's Top Charts section and return a dataframe"""


### PR DESCRIPTION
This modification allows the `today_searches` method to return a Pandas Dataframe with two columns: _query_ and _searches_ instead of one column _query_. I've also updated the documentation to include the `today_searches` method since some people might find it useful.

Returned Dataframe:

**Before**
![Screenshot 2020-11-02 090506](https://user-images.githubusercontent.com/33901325/97839347-b3d5f280-1cea-11eb-988f-7f586bf14045.png)

**After**
![Screenshot 2020-11-02 090402](https://user-images.githubusercontent.com/33901325/97839226-6b1e3980-1cea-11eb-919c-4c341ce233af.png)