### PR TITLE
[trending_searches] correct duplicate keys 'verify' occuring on '_get_date'

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -417,8 +417,7 @@ class TrendReq(object):
         # forms = {'ajax': 1, 'pn': pn, 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=TrendReq.TRENDING_SEARCHES_URL,
-            method=TrendReq.GET_METHOD,
-            **self.requests_args
+            method=TrendReq.GET_METHOD
         )[pn]
         result_df = pd.DataFrame(req_json)
         return result_df


### PR DESCRIPTION
When use trending_searches, kwargs and self.requests_args have same 'verify' argument.
and It makes error.
So I changed "trending_searches" with removing kwargs parameter input.
please check this.