### PR TITLE
Fix fetching interest by region with CITY resolution

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -299,13 +299,17 @@ class TrendReq(object):
             return df
 
         # rename the column with the search keyword
-        df = df[['geoName', 'geoCode', 'value']].set_index(
-            ['geoName']).sort_index()
+        geo_column = 'geoCode' if 'geoCode' in df.columns else 'coordinates'
+        columns = ['geoName', geo_column, 'value']
+        df = df[columns].set_index(['geoName']).sort_index()
         # split list columns into separate ones, remove brackets and split on comma
         result_df = df['value'].apply(lambda x: pd.Series(
             str(x).replace('[', '').replace(']', '').split(',')))
         if inc_geo_code:
-            result_df['geoCode'] = df['geoCode']
+            if geo_column in df.columns:
+                result_df[geo_column] = df[geo_column]
+            else:
+                print('Could not find geo_code column; Skipping')
 
         # rename each column with its search term
         for idx, kw in enumerate(self.kw_list):

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -60,6 +60,11 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.interest_by_region())
 
+    def test_interest_by_region_city_resolution(self):
+        pytrend = TrendReq()
+        pytrend.build_payload(kw_list=['pizza', 'bagel'])
+        self.assertIsNotNone(pytrend.interest_by_region(resolution='CITY'))
+
     def test_related_topics(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])


### PR DESCRIPTION
When fetching interest by region with a CITY resolution, the response doesn't
seem to have the the geoCode column and instead has a coordinates column. This
commit fixes the code to use this column as the geoCode column instead of
raising an error when fetching data with CITY resolution.

Closes #392