### PR TITLE
change append to concat

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -586,7 +586,7 @@ class TrendReq(object):
             try:
                 self.build_payload(keywords, cat, tf, geo, gprop)
                 week_df = self.interest_over_time()
-                df = df.append(week_df)
+                df = pd.concat([df, week_df])
             except Exception as e:
                 print(e)
                 pass
@@ -608,7 +608,7 @@ class TrendReq(object):
                 try:
                     self.build_payload(keywords, cat, tf, geo, gprop)
                     week_df = self.interest_over_time()
-                    df = df.append(week_df)
+                    df = pd.concat([df, week_df])
                 except Exception as e:
                     print(e)
                     pass


### PR DESCRIPTION
The append method on pandas df is deprecated and will be removed in future releases. One could just replace it with concat function instead and achieve the same result.