### PR TITLE
fix requests_args usage for multiple methods

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -428,8 +428,7 @@ class TrendReq(object):
         # forms = {'ajax': 1, 'pn': pn, 'htd': '', 'htv': 'l'}
         req_json = self._get_data(
             url=TrendReq.TRENDING_SEARCHES_URL,
-            method=TrendReq.GET_METHOD,
-            **self.requests_args
+            method=TrendReq.GET_METHOD
         )[pn]
         result_df = pd.DataFrame(req_json)
         return result_df
@@ -441,8 +440,7 @@ class TrendReq(object):
             url=TrendReq.TODAY_SEARCHES_URL,
             method=TrendReq.GET_METHOD,
             trim_chars=5,
-            params=forms,
-            **self.requests_args
+            params=forms
         )['default']['trendingSearchesDays'][0]['trendingSearches']
         result_df = pd.DataFrame()
         # parse the returned json
@@ -508,8 +506,7 @@ class TrendReq(object):
             url=TrendReq.TOP_CHARTS_URL,
             method=TrendReq.GET_METHOD,
             trim_chars=5,
-            params=chart_payload,
-            **self.requests_args
+            params=chart_payload
         )
         try:
             df = pd.DataFrame(req_json['topCharts'][0]['listItems'])
@@ -528,8 +525,7 @@ class TrendReq(object):
             url=TrendReq.SUGGESTIONS_URL + kw_param,
             params=parameters,
             method=TrendReq.GET_METHOD,
-            trim_chars=5,
-            **self.requests_args
+            trim_chars=5
         )['default']['topics']
         return req_json
 
@@ -542,8 +538,7 @@ class TrendReq(object):
             url=TrendReq.CATEGORIES_URL,
             params=params,
             method=TrendReq.GET_METHOD,
-            trim_chars=5,
-            **self.requests_args
+            trim_chars=5
         )
         return req_json
 
@@ -562,7 +557,7 @@ class TrendReq(object):
         # 7 days for hourly
         # ~250 days for daily (270 seems to be max but sometimes breaks?)
         # For weekly can pull any date range so no method required here
-        
+
         if frequency == 'hourly':
             delta = timedelta(days=7)
         elif frequency == 'daily':

--- a/pytrends/test_trendReq.py
+++ b/pytrends/test_trendReq.py
@@ -85,6 +85,15 @@ class TestTrendReq(TestCase):
         pytrend.build_payload(kw_list=['pizza', 'bagel'])
         self.assertIsNotNone(pytrend.realtime_trending_searches(pn='IN'))
 
+    def test_request_args_passing(self):
+        requests_args = {'headers': {
+            'User-Agent': 'pytrends',
+        }}
+        pytrend = TrendReq(requests_args=requests_args)
+        pytrend.build_payload(kw_list=['bananas'])
+        self.assertIsNotNone(pytrend.suggestions('bananas'))
+        self.assertIsNotNone(pytrend.trending_searches())
+
     def test_top_charts(self):
         pytrend = TrendReq()
         pytrend.build_payload(kw_list=['pizza', 'bagel'])


### PR DESCRIPTION
`request_args` are passed twice in `_get_data()` for some methods: 
- directly as `**self.requests_args`
- via `**kwargs`

This leads to the following error:
```python
  File "/usr/local/lib/python3.9/site-packages/pytrends/request.py", line 527, in suggestions
    req_json = self._get_data(
  File "/usr/local/lib/python3.9/site-packages/pytrends/request.py", line 138, in _get_data
    response = s.get(url, timeout=self.timeout, cookies=self.cookies,
TypeError: requests.sessions.Session.get() got multiple values for keyword argument 'headers'
```

This PR fixes #448, fixes #513