### PR TITLE
Fix keyword name issue

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -330,10 +330,9 @@ class TrendReq(object):
         for request_json in self.related_topics_widget_list:
             # ensure we know which keyword we are looking at rather than relying on order
             try:
-                kw = request_json['request']['restriction'][
-                    'complexKeywordsRestriction']['keyword'][0]['value']
+                kw = request_json["keywordName"]
             except KeyError:
-                kw = ''
+                kw = ""
             # convert to string as requests will mangle
             related_payload['req'] = json.dumps(request_json['request'])
             related_payload['token'] = request_json['token']
@@ -382,10 +381,9 @@ class TrendReq(object):
         for request_json in self.related_queries_widget_list:
             # ensure we know which keyword we are looking at rather than relying on order
             try:
-                kw = request_json['request']['restriction'][
-                    'complexKeywordsRestriction']['keyword'][0]['value']
+                kw = request_json["keywordName"]
             except KeyError:
-                kw = ''
+                kw = ""
             # convert to string as requests will mangle
             related_payload['req'] = json.dumps(request_json['request'])
             related_payload['token'] = request_json['token']


### PR DESCRIPTION
Hello,

It is possible to observe compound keywords in the same keyword on Google Trends like '**blockchain + bitcoin**'. Your try except block only takes the first element of the list. That's why, in the dictionary that the function returns, we only find "**blockchain**" as a key but not the real keyword which is "blockchain + bitcoin".

API response example for a given multi keyword:
`[{'type': 'BROAD', 'value': 'blockchain'}, {'type': 'BROAD', 'value': 'bitcoin'}]`

If you don't want to use **keywordName attribute** in PR, here is my second suggestion:

```
try:
    kw = " + ".join(
        each_kw_dict["value"]
        for each_kw_dict in request_json["request"]["restriction"]["complexKeywordsRestriction"][
            "keyword"
        ]
    )
except KeyError:
    kw = ""

```

I work a lot on this kind of keywords, hoping that it will be merged.
Thanks