### PR TITLE
Change GetGoogleCookie request endpoint

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -32,6 +32,7 @@ class TrendReq(object):
     CATEGORIES_URL = f'{BASE_TRENDS_URL}/api/explore/pickers/category'
     TODAY_SEARCHES_URL = f'{BASE_TRENDS_URL}/api/dailytrends'
     REALTIME_TRENDING_SEARCHES_URL = f'{BASE_TRENDS_URL}/api/realtimetrends'
+    EXPLORE_URL = f'{BASE_TRENDS_URL}/explore'
     ERROR_CODES = (500, 502, 504, 429)
 
     def __init__(self, hl='en-US', tz=360, geo='', timeout=(2, 5), proxies='',
@@ -73,7 +74,7 @@ class TrendReq(object):
             if "proxies" in self.requests_args:
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        f'{BASE_TRENDS_URL}/?geo={self.hl[-2:]}',
+                        f'{self.EXPLORE_URL}/?geo={self.hl[-2:]}',
                         timeout=self.timeout,
                         **self.requests_args
                     ).cookies.items()))
@@ -86,7 +87,7 @@ class TrendReq(object):
                     proxy = ''
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        f'{BASE_TRENDS_URL}/?geo={self.hl[-2:]}',
+                        f'{self.EXPLORE_URL}/?geo={self.hl[-2:]}',
                         timeout=self.timeout,
                         proxies=proxy,
                         **self.requests_args

--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -74,7 +74,7 @@ class TrendReq(object):
             if "proxies" in self.requests_args:
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        f'{self.EXPLORE_URL}/?geo={self.hl[-2:]}',
+                        f'{TrendReq.EXPLORE_URL}/?geo={self.hl[-2:]}',
                         timeout=self.timeout,
                         **self.requests_args
                     ).cookies.items()))
@@ -87,7 +87,7 @@ class TrendReq(object):
                     proxy = ''
                 try:
                     return dict(filter(lambda i: i[0] == 'NID', requests.get(
-                        f'{self.EXPLORE_URL}/?geo={self.hl[-2:]}',
+                        f'{TrendReq.EXPLORE_URL}/?geo={self.hl[-2:]}',
                         timeout=self.timeout,
                         proxies=proxy,
                         **self.requests_args


### PR DESCRIPTION
Changing the cookie request URL from `https://trends.google.com/trends` to `https://trends.google.com/trends/explore` seems to fix the immediate 429 errors from the latest frontend update.