### PR TITLE
POST instead of GET to get Google cookie

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -85,7 +85,7 @@ class TrendReq(object):
                 else:
                     proxy = ''
                 try:
-                    return dict(filter(lambda i: i[0] == 'NID', requests.get(
+                    return dict(filter(lambda i: i[0] == 'NID', requests.post(
                         f'{BASE_TRENDS_URL}/?geo={self.hl[-2:]}',
                         timeout=self.timeout,
                         proxies=proxy,


### PR DESCRIPTION
This minor change drastically reduces 429 HTTP status responses