### PR TITLE
Update depercated urllib3 methods

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -5,7 +5,7 @@ import pandas as pd
 import requests
 
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 from requests import status_codes
 
 from pytrends import exceptions
@@ -126,7 +126,7 @@ class TrendReq(object):
                           connect=self.retries,
                           backoff_factor=self.backoff_factor,
                           status_forcelist=TrendReq.ERROR_CODES,
-                          method_whitelist=frozenset(['GET', 'POST']))
+                          allowed_methods=frozenset(['GET', 'POST']))
             s.mount('https://', HTTPAdapter(max_retries=retry))
 
         s.headers.update(self.headers)


### PR DESCRIPTION
1. `requests` no longer has vendored modules in request.package,
2. `urllib3` deprecated Retry options `Retry(method_whitelist=...) `in favor of  `Retry(allowed_methods=...)`