### PR TITLE
Fix pip install command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,8 @@ First of all, create a virtualenv usign `python -m venv` or whatever tool you us
 
 ```bash
 $ python -m venv ~/virtualenvs/pytrends
-$ pip -r install requirements.txt  # library requirements
-$ pip -r install requirements-dev.txt  # development requirements
+$ pip install -r requirements.txt  # library requirements
+$ pip install -r requirements-dev.txt  # development requirements
 ```
 
 ## Running the tests


### PR DESCRIPTION
Corrected the pip install command in the contribution.md file. The original command was `pip -r install requirements.txt`, which is incorrect. The correct command is `pip install -r requirements.txt`. This change ensures clarity and accuracy in the instructions for installing project dependencies.

### Changes Made

```diff
- pip -r install requirements.txt
- pip -r install requirements-dev.txt
+ pip install -r requirements.txt
+ pip install -r requirements-dev.txt