### PR TITLE
Fixed urllib3 deprecation issue

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -126,7 +126,7 @@ class TrendReq(object):
                           connect=self.retries,
                           backoff_factor=self.backoff_factor,
                           status_forcelist=TrendReq.ERROR_CODES,
-                          method_whitelist=frozenset(['GET', 'POST']))
+                          allowed_methods=frozenset(['GET', 'POST']))
             s.mount('https://', HTTPAdapter(max_retries=retry))
 
         s.headers.update(self.headers)


### PR DESCRIPTION
- Updated the **method_whitelist** parameter to **allowed_methods** in accordance with the latest **urllib3** version update.
- This change prevents code termination and ensures smooth execution of **PyTrends**.

This fix addresses compatibility issues due to the recent update in **urllib3** and maintains the functionality of **PyTrends**.