### PR TITLE
Fix interest_over_time warning

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -263,7 +263,8 @@ class TrendReq(object):
         if 'isPartial' in df:
             # make other dataframe from isPartial key data
             # split list columns into seperate ones, remove brackets and split on comma
-            df = df.fillna(False)
+            with pd.option_context("future.no_silent_downcasting", True):
+                df = df.fillna(False)
             result_df2 = df['isPartial'].apply(lambda x: pd.Series(
                 str(x).replace('[', '').replace(']', '').split(',')))
             result_df2.columns = ['isPartial']


### PR DESCRIPTION
With `pandas==2.2.0`, running an interest_over_time() request (a specific one is shown below) leads to the following FutureWarning error from pandas:

```py
from pytrends.request import TrendReq

pytrend = TrendReq(hl='en-US', tz=360)

kw_list = ["D23"]

pytrend.build_payload(kw_list, timeframe='now 1-H')

interest_over_time_df = pytrend.interest_over_time()

print(interest_over_time_df)
```
> C:\Documents\GitHub\Projects\pytrends\pytrends\request.py:266: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
>  df = df.fillna(False)

This PR fixes the appearance of this warning with a one line addition.