### PR TITLE
Show exceptions while loop

### DIFF
--- a/pytrends/request.py
+++ b/pytrends/request.py
@@ -78,7 +78,8 @@ class TrendReq(object):
                         timeout=self.timeout,
                         **self.requests_args
                     ).cookies.items()))
-                except:
+                except Exception as e:
+                    print(f'Proxy error. {e}')
                     continue
             else:
                 if len(self.proxies) > 0:


### PR DESCRIPTION
Show exceptions while loop

Without this, the developers cannot understand why the loops do not work.